### PR TITLE
chore: use last-release-git-tag to determine last version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !/lib/.keep
 /tmp
 npm-debug.log
+.npmrc

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,10 @@
 machine:
   node:
-    version: 5.8.0
+    version: 6.2.0
 
 dependencies:
   pre:
+    - npm prune
     - npm install
 
 test:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "release": {
     "verifyConditions": "condition-circle",
-    "debug": true
+    "getLastRelease": "last-release-git-tag"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "last-release-git-tag": "^1.0.1",
     "babel-cli": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-register": "^6.9.0",


### PR DESCRIPTION
fetching it from npm registry is error prone as the gitHead attribute is
not always there. See
https://github.com/semantic-release/semantic-release/issues/229 for
details