### PR TITLE
test: use better example for test

### DIFF
--- a/test/functions.spec.js
+++ b/test/functions.spec.js
@@ -269,7 +269,7 @@ describe('ceiling', () => {
 
 describe('exp', () => {
   it('Integer Literal', () => {
-    expect(functions.sf$exp(buildLiteralFromJs(10))).to.deep.eq(buildLiteralFromJs(22026.46579480671))
+    expect(functions.sf$exp(buildLiteralFromJs(1))).to.deep.eq(buildLiteralFromJs(2.718281828459045))
   })
 })
 


### PR DESCRIPTION
apparently the precision changed. So I used the example from the JS
documentation:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp