### PR TITLE
Correctly handle arithmetics of the same precedence

### DIFF
--- a/grammars/salesforceFormula.pegjs
+++ b/grammars/salesforceFormula.pegjs
@@ -2,6 +2,24 @@
   function optionalList(value) {
     return value !== null ? value[0] : [];
   }
+
+  function convertArithmetics(operation, head, tail) {
+    {
+      if (tail.type == "callExpression" && tail.id == operation) {
+        return {
+          type: "callExpression",
+          id: operation,
+          arguments: [].concat.apply([], [head, tail.arguments])
+        }
+      } else {
+        return {
+          type: "callExpression",
+          id: operation,
+          arguments: [head, tail]
+        }
+      }
+    }
+  }
 }
 
 start
@@ -94,24 +112,24 @@ LogicalCompareExpression
   / AdditiveExpression
 
 AdditiveExpression
-  = head:(MultiplicativeExpression) __ op:("+" / "-" ) __ tail:AdditiveExpression
+  = head:(MultiplicativeExpression) __ "+" __ tail:AdditiveExpression
   {
-    return {
-      type: "callExpression",
-      id: op === "+" ? "add" : "subtract",
-      arguments: [head, tail]
-    }
+    return convertArithmetics("add", head, tail)
+  }
+  / head:(MultiplicativeExpression) __ "-" __ tail:AdditiveExpression
+  {
+    return convertArithmetics("subtract", head, tail)
   }
   / MultiplicativeExpression
 
 MultiplicativeExpression
-  = head:(ExponentiateExpression) __ op:("*" / "/" ) __ tail:MultiplicativeExpression
+  = head:(ExponentiateExpression) __ "*" __ tail:MultiplicativeExpression
   {
-    return {
-      type: "callExpression",
-      id: op === "*" ? "multiply" : "divide",
-      arguments: [head, tail]
-    }
+    return convertArithmetics("multiply", head, tail)
+  }
+  / head:(ExponentiateExpression) __ "/" __ tail:MultiplicativeExpression
+  {
+    return convertArithmetics("divide", head, tail)
   }
   / ExponentiateExpression
 

--- a/src/functionDispatcher.js
+++ b/src/functionDispatcher.js
@@ -9,10 +9,6 @@ export const dispatch = (name, args) => {
 }
 
 const functionValidations = {
-  add: validateNumOfParams(2),
-  subtract: validateNumOfParams(2),
-  multiply: validateNumOfParams(2),
-  divide: validateNumOfParams(2),
   exponentiate: validateNumOfParams(2),
   and: validateNumOfParams(2),
   or: validateNumOfParams(2),

--- a/src/functions.js
+++ b/src/functions.js
@@ -4,20 +4,24 @@ import { buildLiteralFromJs, sfRound } from './utils'
 
 // Math Operators
 
-export const sf$add = (value1, value2) => {
-  return buildLiteralFromJs(value1.value + value2.value)
+export const sf$add = (...input) => {
+  let values = input.map((v) => v.value)
+  return buildLiteralFromJs(values.reduce((a, b) => a + b))
 }
 
-export const sf$subtract = (value1, value2) => {
-  return buildLiteralFromJs(value1.value - value2.value)
+export const sf$subtract = (...input) => {
+  let values = input.map((v) => v.value)
+  return buildLiteralFromJs(values.reduce((a, b) => a - b))
 }
 
-export const sf$multiply = (value1, value2) => {
-  return buildLiteralFromJs(value1.value * value2.value)
+export const sf$multiply = (...input) => {
+  let values = input.map((v) => v.value)
+  return buildLiteralFromJs(values.reduce((a, b) => a * b))
 }
 
-export const sf$divide = (value1, value2) => {
-  return buildLiteralFromJs(value1.value / value2.value)
+export const sf$divide = (...input) => {
+  let values = input.map((v) => v.value)
+  return buildLiteralFromJs(values.reduce((a, b) => a / b))
 }
 
 export const sf$exponentiate = (value1, value2) => {

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -241,28 +241,22 @@ describe('ast', () => {
               }
             },
             {
-              type: 'callExpression',
-              id: 'add',
-              arguments: [
-                {
-                  type: 'literal',
-                  value: 2,
-                  dataType: 'number',
-                  options: {
-                    length: 1,
-                    scale: 0
-                  }
-                },
-                {
-                  type: 'literal',
-                  value: 3,
-                  dataType: 'number',
-                  options: {
-                    length: 1,
-                    scale: 0
-                  }
-                }
-              ]
+              type: 'literal',
+              value: 2,
+              dataType: 'number',
+              options: {
+                length: 1,
+                scale: 0
+              }
+            },
+            {
+              type: 'literal',
+              value: 3,
+              dataType: 'number',
+              options: {
+                length: 1,
+                scale: 0
+              }
             }
           ]
         }

--- a/test/formulon.spec.js
+++ b/test/formulon.spec.js
@@ -3,7 +3,7 @@
 'use strict'
 
 const expect = require('chai').expect
-import { extract, parse } from '../lib/formulon'
+import { extract, parse, parseAndThrowError } from '../lib/formulon'
 import { buildLiteralFromJs } from '../lib/utils'
 
 describe('Formulon', () => {
@@ -16,6 +16,22 @@ describe('Formulon', () => {
 
         it('returns correct result for subtraction', () => {
           expect(parse('1 - 2')).to.deep.eq(buildLiteralFromJs(-1))
+        })
+
+        it('returns correct result longer subtraction', () => {
+          expect(parseAndThrowError('5 - 2 - 4')).to.deep.eq(buildLiteralFromJs(-1))
+        })
+
+        it('returns correct result longer addition', () => {
+          expect(parseAndThrowError('1 + 2 + 4')).to.deep.eq(buildLiteralFromJs(7))
+        })
+
+        it('returns correct result longer multiplication', () => {
+          expect(parseAndThrowError('2 * 3 * 4')).to.deep.eq(buildLiteralFromJs(24))
+        })
+
+        it('returns correct result longer division', () => {
+          expect(parseAndThrowError('36 / 2 / 3')).to.deep.eq(buildLiteralFromJs(6))
         })
 
         it('returns correct result for function with variable argument list', () => {


### PR DESCRIPTION
In order to handle arithmetics correctly, operators of the same
precedence should not be handled in a recursive way. The easiest way was
to just convert the parameters in a list, when they are from the same
precedence and let the javascript arithmetics figure it out. This
StackOverflow post was really helpful:
http://stackoverflow.com/questions/19390084/parsing-complete-mathematical-expressions-with-peg-js#answer-30798758

fixes #108