### PR TITLE
Add Date data type

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -37,6 +37,15 @@ export const buildErrorLiteral = (errorType, message, options) =>{
   )
 }
 
+export const buildDateLiteral = ( year, month, day ) => {
+  return {
+    type: 'literal',
+    dataType: 'date',
+    value: new Date(year, month - 1, day),
+    options: {}
+  }
+}
+
 export const arrayUnique = (array) => {
   return array.reduce((p, c) => {
     if (p.indexOf(c) < 0) p.push(c)

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -2,7 +2,7 @@
 
 'use strict'
 
-import { arrayUnique, buildErrorLiteral, buildLiteralFromJs, handleFormulonError, sfRound, coerceLiteral } from '../lib/utils'
+import { arrayUnique, buildDateLiteral, buildErrorLiteral, buildLiteralFromJs, handleFormulonError, sfRound, coerceLiteral } from '../lib/utils'
 import { ArgumentError, NoFunctionError, NotImplementedError, ReferenceError } from '../lib/errors'
 
 import { expect } from 'chai'
@@ -98,6 +98,18 @@ describe('buildLiteralFromJs', () => {
 
       expect(fn).to.throw(TypeError, "Unsupported type 'object'")
     })
+  })
+})
+
+describe('buildDateLiteral', () => {
+  it('returns expected literal for year/month/day', () => {
+    let expected = {
+      type: 'literal',
+      value: new Date(2020, 1, 11),
+      dataType: 'date',
+      options: {}
+    }
+    expect(buildDateLiteral(2020, 2, 11)).to.deep.eq(expected)
   })
 })
 


### PR DESCRIPTION
date type includes year, month and day and looks like this:

For 2020-02-11 the type looks like this (JavaScript has zero based
months)

```javascript
{
  type: 'literal',
  value: new Date(2020, 1, 11),
  dataType: 'date',
  options: {}
}
````