### PR TITLE
Add minified build settings (using rollup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 !/lib/.keep
 /tmp
 yarn-error.log
+src/*.grammar.js

--- a/.scripts/make-pegjs.js
+++ b/.scripts/make-pegjs.js
@@ -1,0 +1,19 @@
+const { generate } = require('pegjs');
+const glob = require('glob');
+const { basename } = require('path');
+const { readFileSync, writeFileSync } = require('fs');
+
+glob('grammars/**/*.pegjs', {},(err, files) => {
+  if(err) {
+    console.error(err);
+    process.exit(1);
+  }
+  files.forEach(f => {
+    const grammar = readFileSync(f, 'utf8');
+    const outputName = basename(f, '.pegjs');
+    writeFileSync(
+      `src/${outputName}.grammar.js`,
+      `export default ${generate(grammar, Object.assign({ output: 'source' }, {}))};`
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": ">=11.0.0"
   },
   "scripts": {
-    "build": "yarn compile:parser && babel src --out-dir lib",
-    "compile:parser": "pegjs -o ./lib/timeParser.js ./grammars/salesforceTimeDataType.pegjs && pegjs -o ./lib/salesforceParser.js ./grammars/salesforceFormula.pegjs",
+    "build": "yarn compile:parser && yarn rollup -c",
+    "compile:parser": "node .scripts/make-pegjs",
     "test": "mocha --require @babel/register --recursive --grep @integration --invert",
     "test:integration": "mocha --require @babel/register --recursive --grep @integration",
     "lint": "eslint --ignore-path .gitignore .",
@@ -39,8 +39,11 @@
     "eslint": "^7.0.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-plugin-import": "^2.20.2",
+    "glob": "^7.1.6",
     "mocha": "^8.0.1",
     "pegjs": "^0.10.0",
+    "rollup": "^2.26.5",
+    "rollup-plugin-terser": "^7.0.0",
     "semantic-release": "^17.0.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { terser } from 'rollup-plugin-terser';
+
+export default [{
+  /* NodeJS - CommonJS format */
+  input: 'src/formulon.js',
+  output: {
+    dir: 'lib',
+    format: 'cjs',
+  },
+},
+{
+  // Browsers - UMD format
+
+  input: 'src/formulon.js',
+  output: {
+    file: 'lib/formulon.min.js',
+    format: 'umd',
+    name: 'formulon',
+  },
+  plugins: [
+    terser(),
+  ],
+},
+{
+  // LWC - requires ES code/exports
+  input: 'src/formulon.js',
+  output: {
+    file: 'lib/formulon.lwc.min.js',
+    format: 'esm',
+  },
+  plugins: [
+    terser(),
+  ],
+},
+];

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -1,5 +1,2 @@
-/* eslint-disable global-require, import/no-unresolved */
-export const salesforceParser = require('./salesforceParser.js');
-
-export const timeParser = require('./timeParser.js');
-/* eslint-enable global-require, import/no-unresolved */
+export { default as salesforceParser } from './salesforceFormula.grammar';
+export { default as timeParser } from './salesforceTimeDataType.grammar';

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -3,7 +3,7 @@
 import { expect } from 'chai';
 import {
   build, extract, replace, traverse,
-} from '../lib/ast';
+} from '../src/ast';
 
 describe('ast', () => {
   describe('build', () => {

--- a/test/formulon.spec.js
+++ b/test/formulon.spec.js
@@ -1,8 +1,8 @@
 /* global describe it context */
 
 import { expect } from 'chai';
-import { extract, parse } from '../lib/formulon';
-import { buildLiteralFromJs } from '../lib/utils';
+import { extract, parse } from '../src/formulon';
+import { buildLiteralFromJs } from '../src/utils';
 
 describe('Formulon', () => {
   describe('parse', () => {

--- a/test/functionDispatcher.spec.js
+++ b/test/functionDispatcher.spec.js
@@ -2,8 +2,8 @@
 
 import { expect } from 'chai';
 
-import dispatch from '../lib/functionDispatcher';
-import { buildLiteralFromJs } from '../lib/utils';
+import dispatch from '../src/functionDispatcher';
+import { buildLiteralFromJs } from '../src/utils';
 
 describe('dispatch', () => {
   context('valid input', () => {

--- a/test/functions.spec.js
+++ b/test/functions.spec.js
@@ -11,9 +11,9 @@ import {
   buildPicklistLiteral,
   buildMultipicklistLiteral,
   buildTimeLiteral,
-} from '../lib/utils';
+} from '../src/utils';
 
-import dispatch from '../lib/functionDispatcher';
+import dispatch from '../src/functionDispatcher';
 
 // Date & Time Functions
 

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -20,8 +20,8 @@ import opportunityManagement from './16_opportunity_management.json';
 import pricing from './17_pricing.json';
 import scoringCalculations from './18_scoring_calculations.json';
 
-import { parse } from '../../lib/formulon';
-import { buildDateLiteral, buildDatetimeLiteral, buildLiteralFromJs } from '../../lib/utils';
+import { parse } from '../../src/formulon';
+import { buildDateLiteral, buildDatetimeLiteral, buildLiteralFromJs } from '../../src/utils';
 
 const coerceLiteral = (literal) => {
   switch (literal.dataType) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -17,12 +17,12 @@ import {
   parseTime,
   sfRound,
   coerceLiteral,
-} from '../lib/utils';
+} from '../src/utils';
 
-import ArgumentError from '../lib/errors/ArgumentError';
-import NoFunctionError from '../lib/errors/NoFunctionError';
-import NotImplementedError from '../lib/errors/NotImplementedError';
-import ReferenceError from '../lib/errors/ReferenceError';
+import ArgumentError from '../src/errors/ArgumentError';
+import NoFunctionError from '../src/errors/NoFunctionError';
+import NotImplementedError from '../src/errors/NotImplementedError';
+import ReferenceError from '../src/errors/ReferenceError';
 
 describe('parseTime', () => {
   context('valid time', () => {

--- a/test/validations.spec.js
+++ b/test/validations.spec.js
@@ -1,15 +1,15 @@
 /* global describe it context */
 
 import { expect } from 'chai';
-import { buildLiteralFromJs, buildPicklistLiteral } from '../lib/utils';
+import { buildLiteralFromJs, buildPicklistLiteral } from '../src/utils';
 import {
   caseParams,
   maxNumOfParams,
   minNumOfParams,
   paramTypes,
   sameParamType,
-} from '../lib/validations';
-import ArgumentError from '../lib/errors/ArgumentError';
+} from '../src/validations';
+import ArgumentError from '../src/errors/ArgumentError';
 
 describe('maxNumOfParams', () => {
   context('exact length', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,6 +1228,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.0.tgz#69a23a3ad29caf0097f06eda59b361ee2f0639f6"
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
+"@types/node@*":
+  version "14.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.6.2.tgz#264b44c5a28dfa80198fc2f7b6d3c8a054b9491f"
+  integrity sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==
+
 "@types/node@>= 8":
   version "13.7.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
@@ -2097,15 +2102,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.20.0, commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
-
-commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commitlint@^9.1.2:
   version "9.1.2"
@@ -4117,6 +4122,15 @@ java-properties@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/java-properties/-/java-properties-1.0.2.tgz#ccd1fa73907438a5b5c38982269d0e771fe78211"
   integrity sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==
+
+jest-worker@^26.2.1:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.3.0.tgz#7c8a97e4f4364b4f05ed8bca8ca0c24de091871f"
+  integrity sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==
+  dependencies:
+    "@types/node" "*"
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -6437,6 +6451,23 @@ rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   dependencies:
     glob "^7.1.3"
 
+rollup-plugin-terser@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.1.tgz#df72d8272e03fcb504a76f414b9509c63c5eaf54"
+  integrity sha512-HL0dgzSxBYG/Ly9i/E5Sc+PuKKZ0zBzk11VmLCfdUtpqH4yYqkLclPkTqRy85FU9246yetImOClaQ/ufnj08vg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    jest-worker "^26.2.1"
+    serialize-javascript "^4.0.0"
+    terser "^5.0.0"
+
+rollup@^2.26.5:
+  version "2.26.8"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.26.8.tgz#7b02353835a73c4797f42177a5fa3fc074012713"
+  integrity sha512-li9WaJYc5z9WzV1jhZbPQCrsOpGNsI+Li1qyrn5n745ZNSnlkRlBtj1Hs+Z0Dc2N1+P7HT34UKAEASqN9Th8cg==
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 run-parallel@^1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
@@ -6544,7 +6575,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-serialize-javascript@4.0.0:
+serialize-javascript@4.0.0, serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
@@ -6714,6 +6745,14 @@ source-map-support@^0.5.16:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map-support@~0.5.12:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -7092,6 +7131,15 @@ term-size@^1.2.0:
   integrity sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=
   dependencies:
     execa "^0.7.0"
+
+terser@^5.0.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.2.1.tgz#40b971b8d28b4fe98c9e8c0d073ab48e7bb96cd8"
+  integrity sha512-/AOtjRtAMNGO0fIF6m8HfcvXTw/2AKpsOzDn36tA5RfhRdeXyb4RvHxJ5Pah7iL6dFkLk+gOnCaNHGwJPl6TrQ==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 text-extensions@^1.0.0:
   version "1.9.0"


### PR DESCRIPTION
Hi,

I have made a few adjustments to allow building formulon as a minified file as well as a single CommonJS module (lib/formulon.min.js and lib/formulon.js respectively). This can be used as a Salesforce LWC service component to allow formula parsing within frontend components.

I think this adds many great use cases which aren't currently possible within the LWC ecosystem itself. 

