### PR TITLE
Consider parentheses for logical operations

### DIFF
--- a/grammars/salesforceFormula.peggy
+++ b/grammars/salesforceFormula.peggy
@@ -103,6 +103,7 @@ Term
   / Identifier
   / Literal
   / "(" __ expression:ArithmeticExpression __ ")" { return expression; }
+  / "(" __ expression:LogicalConcatinationExpression __ ")" { return expression; }
 
 CallExpression
   = id:FunctionIdentifier __ args:Arguments {

--- a/test/ast.spec.js
+++ b/test/ast.spec.js
@@ -796,8 +796,126 @@ describe('ast', () => {
         };
         expect(build('2 ^ (8 * 7 + 5)')).to.deep.equal(expected);
       });
+    });
 
-      it('logical comparison and concatination', () => {
+    context('Boolean Algebra', () => {
+      it('simple or', () => {
+        const expected = {
+          type: 'callExpression',
+          id: 'or',
+          arguments: [
+            {
+              type: 'literal',
+              value: true,
+              dataType: 'checkbox',
+              options: {},
+            },
+            {
+              type: 'literal',
+              value: false,
+              dataType: 'checkbox',
+              options: {},
+            },
+          ],
+        };
+
+        expect(build('TRUE || FALSE')).to.deep.equal(expected);
+      });
+
+      it('simple and', () => {
+        const expected = {
+          type: 'callExpression',
+          id: 'and',
+          arguments: [
+            {
+              type: 'literal',
+              value: true,
+              dataType: 'checkbox',
+              options: {},
+            },
+            {
+              type: 'literal',
+              value: false,
+              dataType: 'checkbox',
+              options: {},
+            },
+          ],
+        };
+
+        expect(build('TRUE && FALSE')).to.deep.equal(expected);
+      });
+
+      it('default precedence', () => {
+        const expected = {
+          type: 'callExpression',
+          id: 'or',
+          arguments: [
+            {
+              type: 'literal',
+              value: true,
+              dataType: 'checkbox',
+              options: {},
+            },
+            {
+              type: 'callExpression',
+              id: 'and',
+              arguments: [
+                {
+                  type: 'literal',
+                  value: false,
+                  dataType: 'checkbox',
+                  options: {},
+                },
+                {
+                  type: 'literal',
+                  value: false,
+                  dataType: 'checkbox',
+                  options: {},
+                },
+              ],
+            },
+          ],
+        };
+
+        expect(build('TRUE || FALSE && FALSE')).to.deep.equal(expected);
+      });
+
+      it('overwriting precedence with parentheses', () => {
+        const expected = {
+          type: 'callExpression',
+          id: 'and',
+          arguments: [
+            {
+              type: 'callExpression',
+              id: 'or',
+              arguments: [
+                {
+                  type: 'literal',
+                  value: true,
+                  dataType: 'checkbox',
+                  options: {},
+                },
+                {
+                  type: 'literal',
+                  value: false,
+                  dataType: 'checkbox',
+                  options: {},
+                },
+              ],
+            },
+            {
+              type: 'literal',
+              value: false,
+              dataType: 'checkbox',
+              options: {},
+            },
+          ],
+        };
+
+        expect(build('(TRUE || FALSE) && FALSE')).to.deep.equal(expected);
+      });
+
+      it('logical comparison and concatenation', () => {
         const expected = {
           type: 'callExpression',
           id: 'and',


### PR DESCRIPTION
Raised in #735 by @jamesmelville.

Turns out the parser did not accept parentheses for logical operations. This was a good opportunity to evaluate if the precedence of this operations matches the functionality of the salesforce parser. Turns out: it does.

Will do some research into wether parentheses are allowed in general (wrapping functions in parentheses etc...)
