### PR TITLE
Fix TypeError when all params are null

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,3 +126,4 @@ Formulon exists thanks to the following people who have contributed.
 - [Jordan Henderson](https://github.com/jordanhenderson)
 - [Leif Gensert](https://github.com/leifg)
 - [James Melville](https://github.com/jamesmelville)
+- [Michael Mason](https://github.com/mjmasn)

--- a/src/validations.js
+++ b/src/validations.js
@@ -34,8 +34,10 @@ export const paramTypes = (...paramTypeList) => (fnName) => (params) => {
 };
 
 export const sameParamType = () => (fnName) => (params) => {
-  if (params.length > 0) {
-    params.filter((param) => param.dataType !== 'null').reduce((acc, current) => {
+  const nonNullParams = params.filter((param) => param.dataType !== 'null');
+
+  if (nonNullParams.length > 0) {
+    nonNullParams.reduce((acc, current) => {
       if (acc.dataType !== current.dataType) {
         ArgumentError.throwWrongType(fnName, acc.dataType, current.dataType);
       }

--- a/test/validations.spec.js
+++ b/test/validations.spec.js
@@ -201,6 +201,14 @@ describe('sameParamType', () => {
       expect(fn()).to.eq(undefined);
     });
   });
+
+  context('only null parameters', () => {
+    it('does not throw an error', () => {
+      const params = [buildLiteralFromJs(null), buildLiteralFromJs(null)];
+      const fn = () => sameParamType()('equal')(params);
+      expect(fn()).to.eq(undefined);
+    });
+  });
 });
 
 describe('caseParams', () => {


### PR DESCRIPTION
Currently if all params are null the `sameParamType` validation throws an error: 
> TypeError: reduce of empty array with no initial value

This change adds a length check to skip the reduce if we have no param types to compare