### PR TITLE
Allow appropriate datatypes for IF function

### DIFF
--- a/src/functionDispatcher.js
+++ b/src/functionDispatcher.js
@@ -127,8 +127,8 @@ const existingFunctions = {
     returnType: 'text',
   },
   if: {
-    validations: [minNumOfParams(3), maxNumOfParams(3), paramTypes('checkbox', ['text', 'number', 'date', 'datetime'], ['text', 'number', 'date', 'datetime'])],
-    returnType: ['text', 'number', 'date', 'datetime'],
+    validations: [minNumOfParams(3), maxNumOfParams(3), paramTypes('checkbox', ['text', 'number', 'date', 'datetime', 'checkbox', 'geolocation'], ['text', 'number', 'date', 'datetime', 'checkbox', 'geolocation'])],
+    returnType: ['text', 'number', 'date', 'datetime', 'checkbox', 'geolocation'],
   },
   image: {
     validations: [minNumOfParams(2), maxNumOfParams(4), paramTypes('text', 'text', 'number', 'number')],


### PR DESCRIPTION
I noticed that the functions for `IF` statements didn't support input of return of `checkbox` (I've landed on an org where the admin seems to like writing pointless if statements like `IF(expression, true, false)`). I've tried to spot any other allowed datatypes, the only missing one I spotted was also geolocation. I don't know if it makes sense to add a test here, and maybe check that the inputs for returning are matching datatypes?