### PR TITLE
Ensure exponent operator is an integer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Check functions.js to see if the function you want to implement already has a st
   })
   ```
 
-- Add implemention stub to `functions.js` (sorted by category then alphabetically) that throws `NotImplementedError`
+- Add implementation stub to `functions.js` (sorted by category then alphabetically) that throws `NotImplementedError`
 
   ```javascript
   /* eslint-disable no-unused-vars */

--- a/README.md
+++ b/README.md
@@ -167,3 +167,4 @@ Formulon exists thanks to the following people who have contributed.
 - [James Melville](https://github.com/jamesmelville)
 - [Michael Mason](https://github.com/mjmasn)
 - [Kyle Crouse](https://github.com/kacrouse)
+- [Austin Turner](https://github.com/paustint)

--- a/src/functions.js
+++ b/src/functions.js
@@ -266,6 +266,10 @@ export const sf$exponentiate = (value1, value2) => {
     ArgumentError.throwWrongType('exponentiate', 'number', value2.dataType);
   }
 
+  if (value2.options.scale !== 0) {
+    ArgumentError.throwWrongType('exponentiate', 'integer', value2.dataType);
+  }
+
   return buildLiteralFromJs(
     new Decimal(value1.value)
       .toPower(new Decimal(value2.value))

--- a/test/functions.spec.js
+++ b/test/functions.spec.js
@@ -1110,6 +1110,18 @@ describe('exponentiate', () => {
     });
   });
 
+  context('Decimal, Number', () => {
+    it('exponentiates correctly', () => {
+      expect(dispatch('exponentiate', [buildLiteralFromJs(2.71828), buildLiteralFromJs(5)])).to.deep.eq(buildLiteralFromJs(148.41265995084171));
+    });
+  });
+
+  context('Number, Decimal', () => {
+    it('returns ArgumentError', () => {
+      expect(dispatch('exponentiate', [buildLiteralFromJs(2.71828), buildLiteralFromJs(1.4285714286)])).to.deep.eq(buildErrorLiteral('ArgumentError', "Incorrect parameter type for function 'EXPONENTIATE()'. Expected Integer, received Number", { function: 'exponentiate', expected: 'integer', received: 'number' }));
+    });
+  });
+
   context('Number, Null', () => {
     it('returns ArgumentError', () => {
       expect(dispatch('exponentiate', [buildLiteralFromJs(3), buildLiteralFromJs(null)])).to.deep.eq(buildErrorLiteral('ArgumentError', "Incorrect parameter type for function 'EXPONENTIATE()'. Expected Number, received Null", { function: 'exponentiate', expected: 'number', received: 'null' }));


### PR DESCRIPTION
Salesforce does not allow decimals for and exponents and an error should be returned to match Salesforce.

resolves #1168

reported by https://github.com/jetstreamapp/jetstream/issues/1198