### PR TITLE
Fix escape characters in formula

### DIFF
--- a/grammars/salesforceFormula.peggy
+++ b/grammars/salesforceFormula.peggy
@@ -286,8 +286,14 @@ Literal
   / NullLiteral
 
 StringLiteral
-  = SingleQuote chars:(Character / DoubleQuote)* SingleQuote { return stringLiteral(chars); }
-  / DoubleQuote chars:(Character / SingleQuote)* DoubleQuote { return stringLiteral(chars); }
+  = SingleQuote chars:(EscapedCharacter / Character / DoubleQuote)* SingleQuote { return stringLiteral(chars); }
+  / DoubleQuote chars:(EscapedCharacter / Character / SingleQuote)* DoubleQuote { return stringLiteral(chars); }
+
+EscapedCharacter
+  = "\\" "n" { return "\n"; }
+  / "\\" "r" { return "\r"; }
+  / "\\" "t" { return "\t"; }
+  / "\\" "\\" { return "\\"; }
 
 NumericLiteral
   = DecimalLiteral

--- a/src/formulon.js
+++ b/src/formulon.js
@@ -3,6 +3,7 @@ import {
 } from './ast';
 import {
   arrayUnique, buildLiteralFromJs, coerceLiteral, formatLiteral,
+  preprocessFormulaString,
 } from './utils';
 
 export const parse = (formula, substitutions = {}) => {
@@ -10,7 +11,7 @@ export const parse = (formula, substitutions = {}) => {
     return buildLiteralFromJs('');
   }
 
-  const ast = build(formula);
+  const ast = build(preprocessFormulaString(formula));
 
   const coercedSubstitutions = Object.keys(substitutions).reduce((previous, current) => (
     {

--- a/src/utils.js
+++ b/src/utils.js
@@ -238,3 +238,15 @@ export const formatLiteral = (literal) => {
       return undefined;
   }
 };
+
+export const preprocessFormulaString = (formula) => {
+  if (typeof formula !== 'string') {
+    return formula;
+  }
+
+  return formula
+    .replace(/\t/g, '\\t')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\\/g, '\\\\');
+};

--- a/test/formulon.spec.js
+++ b/test/formulon.spec.js
@@ -88,6 +88,10 @@ describe('Formulon', () => {
         it('returns correct result for string concatenation', () => {
           expect(parse("'a' & 'b'")).to.deep.eq(buildLiteralFromJs('ab'));
         });
+
+        it('returns correct result for string concatenation with escape characters', () => {
+          expect(parse('"\t" & "\n" & "\r" & "\t" & "\\"')).to.deep.eq(buildLiteralFromJs('\\t\\n\\r\\t\\'));
+        });
       });
 
       context('coerce inputs', () => {

--- a/test/functions.spec.js
+++ b/test/functions.spec.js
@@ -1016,6 +1016,10 @@ describe('add', () => {
     it('concats correctly', () => {
       expect(dispatch('add', [buildLiteralFromJs('Black'), buildLiteralFromJs('Jack')])).to.deep.eq(buildLiteralFromJs('BlackJack'));
     });
+
+    it('concats correctly with escape character', () => {
+      expect(dispatch('add', [buildLiteralFromJs('Black'), buildLiteralFromJs('\n')])).to.deep.eq(buildLiteralFromJs('Black\n'));
+    });
   });
 
   context('Text, Null', () => {


### PR DESCRIPTION
Strings with escape characters would produce a syntax error instead of being parsed correctly.

I don't know the exact universe of what Salesforce supports, but I tried all the common ones I could think of and most were not supported and the list that I found ended up being fairly small.

Added a pre-process function since javascript already replaces the scape characters when reading in the string.

I tested on salesforce and observed the same double-escaped value in the results.

resolves #972